### PR TITLE
fixed gcc-6 compiler error.

### DIFF
--- a/mha/libmha/src/mha_signal.cpp
+++ b/mha/libmha/src/mha_signal.cpp
@@ -2570,7 +2570,7 @@ MHASignal::loop_wavefragment_t::loop_wavefragment_t(const mha_wave_t& src, bool 
         break;
     case rms_limit40 :
         // use maximum of RMS and peak-40dB
-        file_level = std::max(sqrt(sumsqr()/std::max(1u,size(*this))),0.01*MHASignal::maxabs(*this));
+        file_level = std::max((double)sqrt(sumsqr()/std::max(1u,size(*this))),0.01*MHASignal::maxabs(*this));
         if( file_level > 0 )
             *this *= 1.0f/file_level;
         break;


### PR DESCRIPTION
std::max needs two double, so we are casting the first parameter to a
double to meet the function definition requirement.