### PR TITLE
build: respect CPPFLAGS and LDFLAGS

### DIFF
--- a/examples/12-ac-to-lsl/Makefile
+++ b/examples/12-ac-to-lsl/Makefile
@@ -14,7 +14,7 @@
 # version 3 along with openMHA.  If not, see <http://www.gnu.org/licenses/>.
 include ../../config.mk
 receive_lsl: receive_lsl.cpp
-	$(CXX) receive_lsl.cpp -std=$(CXXSTANDARD) -g -o receive_lsl -llsl
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) receive_lsl.cpp -std=$(CXXSTANDARD) -g -o receive_lsl -llsl
 # Local Variables:
 # compile-command: "make"
 # End:

--- a/examples/19-lsl-to-ac/Makefile
+++ b/examples/19-lsl-to-ac/Makefile
@@ -17,7 +17,7 @@
 
 include ../../config.mk
 receive_lsl: send_lsl.cpp
-	$(CXX) send_lsl.cpp -std=$(CXXSTANDARD) -g -o send_lsl -llsl
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) send_lsl.cpp -std=$(CXXSTANDARD) -g -o send_lsl -llsl
 # Local Variables:
 # compile-command: "make"
 # End:

--- a/examples/21-compile/Makefile
+++ b/examples/21-compile/Makefile
@@ -53,4 +53,4 @@ clean:
 
 # Compile the plugin
 example21: example21.cpp
-	$(CXX) -shared -o example21$(DYNAMIC_LIB_EXT) $(CXXFLAGS) $(INCLUDES) $(LIBS) $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) $(LDFLAGS) -shared -o example21$(DYNAMIC_LIB_EXT) $< $(LIBS)

--- a/examples/25-matlab-wrapper-advanced/Makefile
+++ b/examples/25-matlab-wrapper-advanced/Makefile
@@ -2,4 +2,4 @@
 # The rule for the compilation of the .o files is provided by Make
 # as an implicit rule
 example_25.so: example_25.o example_25_emxAPI.o example_25_emxutil.o
-	$(CC) -shared -o $@ $^
+	$(CC) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)

--- a/examples/27-matlab-wrapper-spectrum/Makefile
+++ b/examples/27-matlab-wrapper-spectrum/Makefile
@@ -2,4 +2,4 @@
 # The rule for the compilation of the .o files is provided by Make
 # as an implicit rule
 example_27.so: example_27.o example_27_emxAPI.o example_27_emxutil.o
-	$(CC) -shared -o $@ $^
+	$(CC) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)

--- a/examples/28-matlab-wrapper-spec2wave/Makefile
+++ b/examples/28-matlab-wrapper-spec2wave/Makefile
@@ -2,4 +2,4 @@
 # The rule for the compilation of the .o files is provided by Make
 # as an implicit rule
 example_28.so: example_28.o example_28_emxAPI.o example_28_emxutil.o
-	$(CC) -shared -o $@ $^
+	$(CC) $(LDFLAGS) -shared -o $@ $^ $(LDLIBS)

--- a/examples/30-marker-streams/Makefile
+++ b/examples/30-marker-streams/Makefile
@@ -15,7 +15,7 @@
 include ../../config.mk
 
 SendStringMarkers: SendStringMarkers.cpp
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $< -std=$(CXXSTANDARD) -g -o $@ -llsl
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< $(LDFLAGS) -std=$(CXXSTANDARD) -g -o $@ -llsl
 
 ifneq ("$(WITH_LSL)", "yes")
 	$(error This example needs LSL to compile)

--- a/mha/frameworks/Makefile
+++ b/mha/frameworks/Makefile
@@ -103,13 +103,13 @@ src/fw_t.java src/MHA.java src/MHAJNI.java src/fw_t_wrap.cxx: src/fw_t.ii
 	swig3.0 -c++ -java src/fw_t.ii
 
 $(BUILD_DIR)/libMHAfw.so: src/mhafw_lib.cpp $(BUILD_DIR)/frameworks_mha_git_commit_hash.o
-	$(CXX) $(CXXFLAGS) $^ $(LDFLAGS) $(LDLIBS) -shared -o $@ -I/usr/lib/jvm/default-java/include/ -I/usr/lib/jvm/default-java/include/linux -fno-strict-aliasing
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ $(LDFLAGS) $(LDLIBS) -shared -o $@ -I/usr/lib/jvm/default-java/include/ -I/usr/lib/jvm/default-java/include/linux -fno-strict-aliasing
 
 $(BUILD_DIR)/libMHAjava.so: src/fw_t_wrap.cxx $(BUILD_DIR)/frameworks_mha_git_commit_hash.o $(BUILD_DIR)/libMHAfw.so
-	$(CXX) $(CXXFLAGS) $< $(BUILD_DIR)/frameworks_mha_git_commit_hash.o -L$(BUILD_DIR) $(LDFLAGS) -lMHAfw $(LDLIBS) -shared -o $@ -I/usr/lib/jvm/default-java/include/ -I/usr/lib/jvm/default-java/include/linux -fno-strict-aliasing 
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< $(BUILD_DIR)/frameworks_mha_git_commit_hash.o -L$(BUILD_DIR) $(LDFLAGS) -lMHAfw $(LDLIBS) -shared -o $@ -I/usr/lib/jvm/default-java/include/ -I/usr/lib/jvm/default-java/include/linux -fno-strict-aliasing
 
 $(BUILD_DIR)/mha_ruby.so: src/mha_ruby.cpp $(BUILD_DIR)/frameworks_mha_git_commit_hash.o $(BUILD_DIR)/libMHAfw.so
-	$(CXX) $(CXXFLAGS) $< $(BUILD_DIR)/frameworks_mha_git_commit_hash.o -L$(BUILD_DIR) $(LDFLAGS) $$(ruby -rrbconfig -e 'C=RbConfig::CONFIG;printf("-I%s -I%s -L%s %s",C["rubyhdrdir"],C["rubyarchhdrdir"],C["libdir"],C["LIBRUBYARG"])') -lMHAfw $(LDLIBS) -shared -o $@  -fno-strict-aliasing 
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $< $(BUILD_DIR)/frameworks_mha_git_commit_hash.o -L$(BUILD_DIR) $(LDFLAGS) $$(ruby -rrbconfig -e 'C=RbConfig::CONFIG;printf("-I%s -I%s -L%s %s",C["rubyhdrdir"],C["rubyarchhdrdir"],C["libdir"],C["LIBRUBYARG"])') -lMHAfw $(LDLIBS) -shared -o $@  -fno-strict-aliasing
 
 # Local Variables:
 # compile-command: "make"

--- a/mha/libmha/Makefile
+++ b/mha/libmha/Makefile
@@ -101,7 +101,7 @@ endif
 # an explicit dependency.
 $(BUILD_DIR)/unit-test-runner: $(unit_tests_test_files) $(BUILD_DIR)/$(libmha)$(DYNAMIC_LIB_EXT)
 	@echo dependencies = $^
-	$(CXX) $(CXXFLAGS) --coverage -o $@ $(unit_tests_test_files) $(LDFLAGS) $(LDLIBS) $(BUILD_DIR)/$(libmha)$(DYNAMIC_LIB_EXT) -lgmock_main -lgmock -lgtest -lpthread
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) --coverage -o $@ $(unit_tests_test_files) $(LDFLAGS) $(LDLIBS) $(BUILD_DIR)/$(libmha)$(DYNAMIC_LIB_EXT) -lgmock_main -lgmock -lgtest -lpthread
 
 # Local Variables:
 # coding: utf-8-unix

--- a/mha/tools/fitting/NAL-NL2/Makefile
+++ b/mha/tools/fitting/NAL-NL2/Makefile
@@ -1,10 +1,10 @@
 LDLIBS=NAL-NL2.lib
 CXXFLAGS=-std=c++17 -ggdb --static
 nalnl2wrapper: nalnl2wrapper.cpp parser.cpp parser.hh nalnl2wrapper.hh NAL-NL2.lib
-	$(CXX) $(CXXFLAGS) -o $@ nalnl2wrapper.cpp parser.cpp $(LDLIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ nalnl2wrapper.cpp parser.cpp $(LDFLAGS) $(LDLIBS)
 
 clean:
 	rm -f nalnl2wrapper
 
 test: test.cpp parser.cpp parser.hh
-	$(CXX) $(CXXFLAGS) -o $@ test.cpp parser.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ test.cpp parser.cpp $(LDFLAGS) $(LDLIBS)

--- a/rules.mk
+++ b/rules.mk
@@ -38,24 +38,24 @@ all: $(BUILD_DIR)/.directory $(patsubst %,$(BUILD_DIR)/%,$(TARGETS)) $(PLUGIN_AR
 
 # Pattern for building object files from C++ sources - with headers
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp $(SOURCE_DIR)/%.hh $(BUILD_DIR)/.directory
-	$(CXX) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
 
 # Pattern for building object files from C++ sources - w/o headers
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.cpp $(BUILD_DIR)/.directory
-	$(CXX) $(CXXFLAGS) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
 
 # Pattern for building object files from C sources - with headers
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c $(SOURCE_DIR)/%.h $(BUILD_DIR)/.directory
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 # Pattern for building object files from C sources - w/o headers
 $(BUILD_DIR)/%.o: $(SOURCE_DIR)/%.c $(BUILD_DIR)/.directory
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 
 # Pattern for building object containing the git commit hash for reproducibility
 $(BUILD_DIR)/%_mha_git_commit_hash.o: $(GIT_DIR)/mha/libmha/src/mha_git_commit_hash.cpp $(BUILD_DIR)/.directory
-	$(CXX) $(CXXFLAGS) $(GITCOMMITHASHCFLAGS) -c -o $@ $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(GITCOMMITHASHCFLAGS) -c -o $@ $<
 
 # Pattern for linking shared libraries and dynamic plugins
 $(BUILD_DIR)/%$(DYNAMIC_LIB_EXT):
@@ -94,7 +94,7 @@ execute-unit-tests: $(BUILD_DIR)/unit-test-runner
 unit_tests_test_files = $(wildcard $(SOURCE_DIR)/*_unit_tests.cpp)
 
 $(BUILD_DIR)/unit-test-runner: $(BUILD_DIR)/.directory $(unit_tests_test_files) $(patsubst %_unit_tests.cpp, %.cpp , $(unit_tests_test_files))
-	if test -n "$(unit_tests_test_files)"; then $(CXX) $(CXXFLAGS) --coverage -o $@ $(wordlist 2, $(words $^), $^) $(LDFLAGS) $(LDLIBS) -lgmock_main -lgmock -lgtest -lpthread; fi
+	if test -n "$(unit_tests_test_files)"; then $(CXX) $(CPPFLAGS) $(CXXFLAGS) --coverage -o $@ $(wordlist 2, $(words $^), $^) $(LDFLAGS) $(LDLIBS) -lgmock_main -lgmock -lgtest -lpthread; fi
 
 # Static Pattern Rule defines standard prerequisites for plugins
 $(PLUGINS:%=$(BUILD_DIR)/%$(PLUGIN_EXT)): %$(PLUGIN_EXT): %.o %_mha_git_commit_hash.o


### PR DESCRIPTION
Use CPPFLAGS in compile and link rules where missing. Use LDFLAGS in link rules where missing.

This makes the Makefile-based build respect the standard variables used by callers and downstream packaging systems for preprocessor and linker options without requiring those flags to be folded into CFLAGS or CXXFLAGS.