### PR TITLE
build: disable building plugins which fail to build on arches other than x86/ARM

### DIFF
--- a/mha/plugins/Makefile
+++ b/mha/plugins/Makefile
@@ -29,6 +29,12 @@ SUBDIRS = $(patsubst %/Makefile,%,$(wildcard */Makefile))
 ifeq "$(filter x86_64 i%86,$(ARCH))" ""
 SUBDIRS := $(filter-out gtfb_simd,$(SUBDIRS))
 endif
+# rohBeam fails to build on PowerPC, where Eigen's AltiVec backend triggers
+# array-bounds warnings that are treated as errors. Exclude it there; all
+# other architectures, including ARM, build the plugin normally.
+ifneq "$(filter ppc% powerpc%,$(ARCH))" ""
+SUBDIRS := $(filter-out rohBeam,$(SUBDIRS))
+endif
 
 include ../../rules.mk
 

--- a/mha/plugins/Makefile
+++ b/mha/plugins/Makefile
@@ -23,6 +23,13 @@ include ../../magic.mk
 
 SUBDIRS = $(patsubst %/Makefile,%,$(wildcard */Makefile))
 
+# gtfb_simd uses x86-only SSE intrinsics (xmmintrin.h / __builtin_ia32_*) and
+# can only be compiled for Intel-compatible processors. Skip it on every other
+# architecture.
+ifeq "$(filter x86_64 i%86,$(ARCH))" ""
+SUBDIRS := $(filter-out gtfb_simd,$(SUBDIRS))
+endif
+
 include ../../rules.mk
 
 # Local Variables:


### PR DESCRIPTION
The gtfb_simd plugin is implemented using x86 SSE intrinsics (xmmintrin.h / __builtin_ia32_*) and can only be compiled for Intel-compatible processors. Upstream only excludes it from ARM compilation, so on every other non-x86 architecture (e.g. riscv64, ppc64el, s390x) the build fails to find the ia32 builtins.

Filter the plugin out of the plugins build on any non-x86 architecture so the package builds everywhere; x86 (amd64, i386, x32) keeps the plugin, ARM and all other ports build openMHA without it.