### PR TITLE
mhatest: relax test_amvdr_bf tolerance for 32-bit x86

### DIFF
--- a/mha/mhatest/test_amvdr_bf.m
+++ b/mha/mhatest/test_amvdr_bf.m
@@ -49,7 +49,10 @@ function test_amvdr_bf
   yAlgo = audioread(outwav);
 
   %% Test fidelity - 1e-7 is an empiric value
-  assert_difference_below(refyAlgo,yAlgo,1e-7);
+  %% Relaxed to 2e-7 to accommodate x87 vs SSE floating-point rounding
+  %% differences on 32-bit x86 (i386), where the result diverges from the
+  %% reference by ~1.04e-7, just above the original threshold.
+  assert_difference_below(refyAlgo,yAlgo,2e-7);
 end
 
 % Local Variables:


### PR DESCRIPTION
The AMVDR beamformer test compares the algorithm output against a reference WAV file with a fixed absolute tolerance of 1e-7. As the audio samples are single-precision floats, this tolerance sits right at the float32 precision floor (machine epsilon ~1.19e-7).

On i386 the result diverges from the reference by ~1.04e-7, just above the original threshold and the test fails. amd64 passes because it uses SSE math, whereas i386 defaults to the x87 FPU and its 80-bit extended precision intermediates round differently. This is a floating-point rounding artifact rather than an algorithmic defect.

Relax the tolerance to 2e-7 to give comfortable headroom for cross architecture rounding differences while keeping the test meaningful.