### PR TITLE
docs: disable generating Doxygen Files pages

### DIFF
--- a/mha/doc/Makefile
+++ b/mha/doc/Makefile
@@ -103,8 +103,10 @@ mhadoc: images
 
 plugins: $(MHADISTS:=_plugins.pdf)
 
-%_plugin.list: 
-	echo $(PLUGIN_NAMES)"\n"$(IO_NAMES) | sort > $@
+%_plugin.list:
+	# Sort in the C locale so the plugin ordering - and therefore the
+	# generated plugins manual - does not depend on the build's locale.
+	echo $(PLUGIN_NAMES)"\n"$(IO_NAMES) | LC_ALL=C sort > $@
 
 %_plugin_section.tex: %_plugin.list
 	MHA_PARSER_PRECISION=5 LD_LIBRARY_PATH="$(LD_LIBRARY_PATH):$(MATLAB_LIBS)" MHA_LIBRARY_PATH="$(MHA_PLUGINDIRS)" ../frameworks/$(BUILD_DIR)/generatemhaplugindoc -o $@ -c subsection -p subsubsection `cat $<` 

--- a/mha/doc/mhaextern.cfg
+++ b/mha/doc/mhaextern.cfg
@@ -654,7 +654,7 @@ SHOW_USED_FILES        = YES
 # (if specified).
 # The default value is: YES.
 
-SHOW_FILES             = YES
+SHOW_FILES             = NO
 
 # Set the SHOW_NAMESPACES tag to NO to disable the generation of the Namespaces
 # page. This will remove the Namespaces entry from the Quick Index and from the

--- a/mha/doc/mhaplugins.cfg
+++ b/mha/doc/mhaplugins.cfg
@@ -655,7 +655,7 @@ SHOW_USED_FILES        = YES
 # (if specified).
 # The default value is: YES.
 
-SHOW_FILES             = YES
+SHOW_FILES             = NO
 
 # Set the SHOW_NAMESPACES tag to NO to disable the generation of the Namespaces
 # page. This will remove the Namespaces entry from the Quick Index and from the


### PR DESCRIPTION
Set SHOW_FILES to NO to avoid generating the Doxygen Files pages which
should improve documentation reproducibility by reducing output that
may vary between build environments.