### PR TITLE
make clean now cleans all generated artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ doc: mha/doc
 
 clean:
 	for m in $(MODULES) $(DOCMODULES); do $(MAKE) -C $$m clean; done
+	# Remove the manuals and the manuals archive copied here by the doc target.
+	rm -f openMHA_*.pdf pdf-*.zip
 
 ifeq "$(PLATFORM)" "Darwin"
 INSTALL_NAME_TOOL=install_name_tool

--- a/external_libs/Makefile
+++ b/external_libs/Makefile
@@ -164,6 +164,14 @@ $(BUILD_DIR)/libemx.is_installed: $(BUILD_DIR)/include/.directory $(BUILD_DIR)/l
 	cp -v libemx/src/types.h $(BUILD_DIR)/include/libemx_types.h
 	touch $@
 
+# libemx is built by the explicit rule above rather than via SUBDIRS, so the
+# generic clean target does not descend into it and would leave libemx's own
+# build directory behind. Clean it explicitly.
+clean: clean-libemx
+.PHONY: clean-libemx
+clean-libemx:
+	$(MAKE) -C libemx clean
+
 libxdf: $(BUILD_DIR)/libxdf.is_installed 
 
 $(BUILD_DIR)/libxdf.is_installed: $(BUILD_DIR)/include/.directory $(BUILD_DIR)/lib/.directory

--- a/mha/doc/Makefile
+++ b/mha/doc/Makefile
@@ -130,8 +130,17 @@ plugins: $(MHADISTS:=_plugins.pdf)
 	rm -f $*.{aux,dvi,log,toc,out,idx,ilg}
 
 clean:
-	rm -f $(MHADISTS:=_plugins.*) *~ $(MHANAME)_developer_manual.pdf $(MHANAME)_application_manual.pdf $(MHANAME)_gui_manual.pdf
+	rm -f $(MHADISTS:=_plugins.*) $(MHADISTS:=_plugin.list) *~ \
+	  $(MHANAME)_developer_manual.pdf $(MHANAME)_application_manual.pdf \
+	  $(MHANAME)_gui_manual.pdf $(MHANAME)_calibration_manual.pdf \
+	  $(MHANAME)_starting_guide.pdf $(MHANAME)_matlab_coder_integration.pdf
+	rm -Rf mhadoc
+	$(MAKE) -C images clean
+	$(MAKE) -C flowcharts clean
 	$(MAKE) -C user_manual clean
+	$(MAKE) -C calibration clean
+	$(MAKE) -C starting_guide clean
+	$(MAKE) -C matlab_coder_integration clean
 
 # Local Variables:
 # coding: utf-8-unix

--- a/mha/doc/calibration/Makefile
+++ b/mha/doc/calibration/Makefile
@@ -34,7 +34,7 @@ all: $(MHANAME)_calibration_manual.pdf
 	TEXINPUTS=$(TEXINPUTS) pdflatex $(PDFLATEX_FLAGS) $<
 
 clean:
-	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out $(MHANAME)_calibration_manual.pdf
+	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out *-eps-converted-to.pdf $(MHANAME)_calibration_manual.pdf
 
 $(MHANAME)_calibration_manual.pdf: $(MHANAME)_calibration_manual.tex ../openMHAdoxygen.sty
 

--- a/mha/doc/matlab_coder_integration/Makefile
+++ b/mha/doc/matlab_coder_integration/Makefile
@@ -34,8 +34,8 @@ TEXINPUTS = ""
 	TEXINPUTS=$(TEXINPUTS) pdflatex $(PDFLATEX_FLAGS) $<
 
 clean:
-	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out \
-  $(MHANAME)_application_manual.pdf $(MHANAME)_gui_manual.pdf plug_*.tex
+	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out *-eps-converted-to.pdf \
+  $(MHANAME)_matlab_coder_integration.pdf $(MHANAME)_application_manual.pdf $(MHANAME)_gui_manual.pdf plug_*.tex
 
 $(MHANAME)_matlab_coder_integration: $(MHANAME)_matlab_coder_integration.tex ../openMHAdoxygen.sty $(wildcard *.tex)
 

--- a/mha/doc/starting_guide/Makefile
+++ b/mha/doc/starting_guide/Makefile
@@ -34,7 +34,7 @@ TEXINPUTS = "./:../:./plugins/:../technical_report/:../flowcharts/fmt_eps/:../fl
 	TEXINPUTS=$(TEXINPUTS) pdflatex $(PDFLATEX_FLAGS) $<
 
 clean:
-	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out $(MHANAME)_application_manual.pdf $(MHANAME)_gui_manual.pdf plug_*.tex
+	rm -Rf *.log *.lot *.lof *.aux *.dep *.dvi *.toc *~ *.blg *.bbl *.ilg *.ind *.idx *.out *-eps-converted-to.pdf $(MHANAME)_starting_guide.pdf $(MHANAME)_application_manual.pdf $(MHANAME)_gui_manual.pdf plug_*.tex
 
 $(MHANAME)_starting_guide: $(MHANAME)_starting_guide.tex ../openMHAdoxygen.sty $(wildcard *.tex)
 


### PR DESCRIPTION
The clean targets for the documentation only removed a subset of the files produced by `make doc`. Building the documentation and then cleaning left many generated files behind, which breaks a second build of the Debian package (dpkg-source detects the leftover files as local changes to the source tree).

Extend the clean targets to remove everything generated by the doc build.